### PR TITLE
CHA-2500: Linux RPM installer (RH/Fedora) constant

### DIFF
--- a/pkg/model/model/globals.go
+++ b/pkg/model/model/globals.go
@@ -268,3 +268,4 @@ var AgentClasses = map[string]map[string]bool{
 
 const GenericPraetorianAegisInstallerMsi = "PraetorianAegisInstaller_generic.msi"
 const GenericPraetorianAegisInstallerDeb = "PraetorianAegisInstaller_generic.deb"
+const GenericPraetorianAegisInstallerRpm = "PraetorianAegisInstaller_generic.rpm"


### PR DESCRIPTION
Simple constant for RPM installers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for referencing the generic Praetorian Aegis installer in RPM format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->