### PR TITLE
Add Okta credential type for SSO integration

### DIFF
--- a/pkg/model/model/credential.go
+++ b/pkg/model/model/credential.go
@@ -49,6 +49,7 @@ const (
 	WizCredential                  CredentialType = "wiz"                   // Wiz credentials
 	WhoxyCredential                CredentialType = "whoxy"                 // Whoxy API key
 	XpanseCredential               CredentialType = "xpanse"                // Xpanse credentials
+	OktaCredential                 CredentialType = "okta"                  // Okta API credentials
 
 	LegacyCloudCredential CredentialType = "legacy-cloud" // Legacy cloud credentials (AWS, GCP, Azure)
 


### PR DESCRIPTION
## Summary
- Added `OktaCredential` type to the credential model to support Okta API authentication
- Enables secure storage and management of Okta API tokens for the comprehensive Okta SSO integration feature

## Changes
- Added `OktaCredential` constant to `credential.go`

## Test Plan
- [x] Code compiles successfully
- [x] Credential type follows existing patterns
- [x] Will be tested as part of the main Okta integration feature

## Related PRs
- Main implementation: praetorian-inc/chariot#[pending]

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for Okta API credentials as a new credential type.
  - Users can now configure and store Okta credentials for integrations that require Okta access.
  - Enables authentication to Okta-based services within workflows and connectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->