### PR TITLE
Add DockerHub as a valid repository

### DIFF
--- a/pkg/model/model/repository.go
+++ b/pkg/model/model/repository.go
@@ -24,7 +24,7 @@ const (
 )
 
 var (
-	repository    = regexp.MustCompile(`^(https://)?(github\.com|gitlab\.com|bitbucket\.(com|org))/([^/]+)/(([^/]+/)*[^/]+)$`)
+	repository    = regexp.MustCompile(`^(https://)?(github\.com|gitlab\.com|bitbucket\.(com|org)|hub\.docker\.com)/([^/]+)/(([^/]+/)*[^/]+)$`)
 	repositoryKey = regexp.MustCompile(`^#repository(#[^#]+){2,}$`)
 )
 
@@ -111,7 +111,7 @@ func (r *Repository) extractOrgAndRepo() error {
 		return fmt.Errorf("invalid repository URL: %s", r.URL)
 	}
 	r.Name = parts[len(parts)-1]
-	r.Org = parts[3]
+	r.Org = parts[len(parts)-2]
 	return nil
 }
 

--- a/pkg/model/model/repository_test.go
+++ b/pkg/model/model/repository_test.go
@@ -40,6 +40,14 @@ func TestRepository_NewRepository(t *testing.T) {
 	assert.Equal(t, "repository", repo.Class)
 	assert.Equal(t, "#repository#https://bitbucket.org/praetorian-inc/tabularium#tabularium", repo.Key)
 
+	// full dockerhub URL
+	repo = NewRepository("https://hub.docker.com/r/praetorian-inc/tabularium")
+	assert.Equal(t, "praetorian-inc", repo.Org)
+	assert.Equal(t, "tabularium", repo.Name)
+	assert.Equal(t, "https://hub.docker.com/r/praetorian-inc/tabularium", repo.URL)
+	assert.Equal(t, "repository", repo.Class)
+	assert.Equal(t, "#repository#https://hub.docker.com/r/praetorian-inc/tabularium#tabularium", repo.Key)
+
 	// partial URL - missing schema
 	repo = NewRepository("github.com/praetorian-inc/tabularium")
 	assert.Equal(t, "praetorian-inc", repo.Org)
@@ -69,6 +77,9 @@ func TestRepository_Valid(t *testing.T) {
 	assert.True(t, repo.Valid())
 
 	repo = NewRepository("https://bitbucket.org/praetorian-inc/tabularium")
+	assert.True(t, repo.Valid())
+
+	repo = NewRepository("https://hub.docker.com/r/praetorian-inc/tabularium")
 	assert.True(t, repo.Valid())
 
 	repo = NewRepository("github.com/praetorian-inc/tabularium")


### PR DESCRIPTION
Add `hub.docker.com` as another valid repository. The Docker Hub repo URL is formatted in the following way: `https://hub.docker.com/r/org/image` which requires the parsing for the org to change slightly. This parsing still works for the other repository URLs though (verified by the unit tests).

Related to https://praetorianlabs.atlassian.net/browse/CHA-998.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for parsing and validating Docker Hub repository URLs, with correct organization/repository extraction, canonical URLs, and consistent key generation alongside existing GitHub/GitLab/Bitbucket support.
* **Tests**
  * Added tests covering Docker Hub URL handling, including validation and accurate field population.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->