### PR TITLE
Beta Tagging

### DIFF
--- a/pkg/model/beta/beta.go
+++ b/pkg/model/beta/beta.go
@@ -19,7 +19,7 @@ func (b Beta) IsBeta() bool {
 
 // betaValue is the actual type that implements the marshaling logic.
 // when a Marshaler type is anonymously embedded, its marshaling logic
-// hijacks the parent's marshaling logic. This will erase all of the 
+// hijacks the parent's marshaling logic. This will erase all of the
 // parent's other fields. Therefore, we must embed the actual marshaling
 // logic one layer deeper than Beta.
 type betaValue struct{}
@@ -35,4 +35,16 @@ func (b betaValue) MarshalMap(out map[string]any) error {
 
 func (b betaValue) MarshalDynamoDBAttributeValue() (types.AttributeValue, error) {
 	return &types.AttributeValueMemberBOOL{Value: true}, nil
+}
+
+func (b *betaValue) UnmarshalJSON(_ []byte) error {
+	return nil
+}
+
+func (b *betaValue) UnmarshalMap(_ map[string]any) error {
+	return nil
+}
+
+func (b *betaValue) UnmarshalDynamoDBAttributeValue(_ types.AttributeValue) error {
+	return nil
 }

--- a/pkg/model/beta/beta.go
+++ b/pkg/model/beta/beta.go
@@ -1,0 +1,38 @@
+package beta
+
+import (
+	"encoding/json"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+// Beta is a marker type that can be embedded anonymously in structs
+// to mark them as beta features. When embedded, it automatically adds
+// "beta": true to various marshaled output formats.
+type Beta struct {
+	Beta betaValue `neo4j:"beta" json:"beta" dynamodbav:"beta"`
+}
+
+func (b Beta) IsBeta() bool {
+	return true
+}
+
+// betaValue is the actual type that implements the marshaling logic.
+// when a Marshaler type is anonymously embedded, its marshaling logic
+// hijacks the parent's marshaling logic. This will erase all of the 
+// parent's other fields. Therefore, we must embed the actual marshaling
+// logic one layer deeper than Beta.
+type betaValue struct{}
+
+func (b betaValue) MarshalJSON() ([]byte, error) {
+	return json.Marshal(true)
+}
+
+func (b betaValue) MarshalMap(out map[string]any) error {
+	out["beta"] = true
+	return nil
+}
+
+func (b betaValue) MarshalDynamoDBAttributeValue() (types.AttributeValue, error) {
+	return &types.AttributeValueMemberBOOL{Value: true}, nil
+}

--- a/pkg/model/beta/beta_test.go
+++ b/pkg/model/beta/beta_test.go
@@ -66,3 +66,130 @@ func TestBeta_MarshalDynamoDBAttributeValue(t *testing.T) {
 		assert.Equal(t, true, attribute.Value)
 	})
 }
+
+func TestBeta_UnmarshalJSON(t *testing.T) {
+	t.Run("simple unmarshal", func(t *testing.T) {
+		b := beta.Beta{}
+
+		data := []byte(`{}`)
+		err := json.Unmarshal(data, &b)
+		require.NoError(t, err)
+		assert.True(t, b.IsBeta())
+	})
+
+	t.Run("simple unmarshal should ignore true beta value", func(t *testing.T) {
+		b := beta.Beta{}
+
+		data := []byte(`{"beta":true}`)
+		err := json.Unmarshal(data, &b)
+		require.NoError(t, err)
+		assert.True(t, b.IsBeta())
+	})
+
+	t.Run("simple unmarshal should ignore false beta value", func(t *testing.T) {
+		b := beta.Beta{}
+
+		data := []byte(`{"beta":false}`)
+		err := json.Unmarshal(data, &b)
+		require.NoError(t, err)
+		assert.True(t, b.IsBeta())
+	})
+
+	t.Run("embedded unmarshal", func(t *testing.T) {
+		b := TestBetaType{}
+
+		data := []byte(`{"id":"test-id","name":"Test Name"}`)
+		err := json.Unmarshal(data, &b)
+		require.NoError(t, err)
+		assert.True(t, b.IsBeta())
+	})
+
+	t.Run("embedded unmarshal should ignore true beta value", func(t *testing.T) {
+		b := TestBetaType{}
+
+		data := []byte(`{"beta":true,"id":"test-id","name":"Test Name"}`)
+		err := json.Unmarshal(data, &b)
+		require.NoError(t, err)
+		assert.True(t, b.IsBeta())
+	})
+
+	t.Run("embedded unmarshal should ignore false beta value", func(t *testing.T) {
+		b := TestBetaType{}
+
+		data := []byte(`{"beta":false,"id":"test-id","name":"Test Name"}`)
+		err := json.Unmarshal(data, &b)
+		require.NoError(t, err)
+		assert.True(t, b.IsBeta())
+	})
+}
+
+func TestBeta_UnmarshalDynamoDBAttributeValue(t *testing.T) {
+	t.Run("simple unmarshal", func(t *testing.T) {
+		avs := map[string]types.AttributeValue{}
+
+		b := beta.Beta{}
+		err := attributevalue.UnmarshalMap(avs, &b)
+		require.NoError(t, err)
+		assert.True(t, b.IsBeta())
+	})
+
+	t.Run("simple unmarshal should ignore true beta value", func(t *testing.T) {
+		avs := map[string]types.AttributeValue{
+			"beta": &types.AttributeValueMemberBOOL{Value: true},
+		}
+
+		b := beta.Beta{}
+		err := attributevalue.UnmarshalMap(avs, &b)
+		require.NoError(t, err)
+		assert.True(t, b.IsBeta())
+	})
+
+	t.Run("simple unmarshal should ignore false beta value", func(t *testing.T) {
+		avs := map[string]types.AttributeValue{
+			"beta": &types.AttributeValueMemberBOOL{Value: false},
+		}
+
+		b := beta.Beta{}
+		err := attributevalue.UnmarshalMap(avs, &b)
+		require.NoError(t, err)
+		assert.True(t, b.IsBeta())
+	})
+
+	t.Run("embedded unmarshal", func(t *testing.T) {
+		avs := map[string]types.AttributeValue{
+			"id":   &types.AttributeValueMemberS{Value: "test-id"},
+			"name": &types.AttributeValueMemberS{Value: "Test Name"},
+		}
+
+		b := TestBetaType{}
+		err := attributevalue.UnmarshalMap(avs, &b)
+		require.NoError(t, err)
+		assert.True(t, b.IsBeta())
+	})
+
+	t.Run("embedded unmarshal should ignore true beta value", func(t *testing.T) {
+		avs := map[string]types.AttributeValue{
+			"beta": &types.AttributeValueMemberBOOL{Value: true},
+			"id":   &types.AttributeValueMemberS{Value: "test-id"},
+			"name": &types.AttributeValueMemberS{Value: "Test Name"},
+		}
+
+		b := TestBetaType{}
+		err := attributevalue.UnmarshalMap(avs, &b)
+		require.NoError(t, err)
+		assert.True(t, b.IsBeta())
+	})
+
+	t.Run("embedded unmarshal should ignore false beta value", func(t *testing.T) {
+		avs := map[string]types.AttributeValue{
+			"beta": &types.AttributeValueMemberBOOL{Value: false},
+			"id":   &types.AttributeValueMemberS{Value: "test-id"},
+			"name": &types.AttributeValueMemberS{Value: "Test Name"},
+		}
+
+		b := TestBetaType{}
+		err := attributevalue.UnmarshalMap(avs, &b)
+		require.NoError(t, err)
+		assert.True(t, b.IsBeta())
+	})
+}

--- a/pkg/model/beta/beta_test.go
+++ b/pkg/model/beta/beta_test.go
@@ -1,0 +1,68 @@
+package beta_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/praetorian-inc/tabularium/pkg/model/beta"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type TestBetaType struct {
+	beta.Beta
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func TestBeta_MarshalJSON(t *testing.T) {
+	t.Run("standalone beta marshals correctly", func(t *testing.T) {
+		b := beta.Beta{}
+		data, err := json.Marshal(b)
+		require.NoError(t, err)
+
+		expected := `{"beta":true}`
+		assert.JSONEq(t, expected, string(data))
+	})
+
+	t.Run("embedded beta adds beta field to JSON", func(t *testing.T) {
+		testObj := TestBetaType{
+			ID:   "test-id",
+			Name: "Test Name",
+		}
+
+		data, err := json.Marshal(testObj)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"beta":true,"id":"test-id","name":"Test Name"}`, string(data))
+	})
+}
+
+func TestBeta_MarshalDynamoDBAttributeValue(t *testing.T) {
+	t.Run("MarshalDynamoDBAttributeValue returns boolean true", func(t *testing.T) {
+		b := beta.Beta{}
+
+		attributes, err := attributevalue.MarshalMap(b)
+		require.NoError(t, err)
+
+		attribute, ok := attributes["beta"].(*types.AttributeValueMemberBOOL)
+
+		require.True(t, ok)
+		assert.Equal(t, true, attribute.Value)
+	})
+
+	t.Run("embedded beta adds beta field to DynamoDB", func(t *testing.T) {
+		testObj := TestBetaType{
+			ID:   "test-id",
+			Name: "Test Name",
+		}
+
+		attributes, err := attributevalue.MarshalMap(testObj)
+		require.NoError(t, err)
+
+		attribute, ok := attributes["beta"].(*types.AttributeValueMemberBOOL)
+		require.True(t, ok)
+		assert.Equal(t, true, attribute.Value)
+	})
+}

--- a/pkg/model/filters/filter.go
+++ b/pkg/model/filters/filter.go
@@ -91,4 +91,5 @@ const (
 	OperatorAnd                = "AND"
 	OperatorIn                 = "IN"
 	OperatorIsNotNull          = "IS NOT NULL"
+	OperatorIsNull             = "IS NULL"
 )

--- a/pkg/model/model/ad_domain.go
+++ b/pkg/model/model/ad_domain.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/praetorian-inc/tabularium/pkg/model/beta"
 	"github.com/praetorian-inc/tabularium/pkg/registry"
 )
 
@@ -23,7 +22,6 @@ var (
 
 type ADDomain struct {
 	BaseAsset
-	beta.Beta
 	Name string `neo4j:"name" json:"name" desc:"NetBIOS of the domain." example:"example.internal"`
 }
 

--- a/pkg/model/model/ad_domain.go
+++ b/pkg/model/model/ad_domain.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/praetorian-inc/tabularium/pkg/model/beta"
 	"github.com/praetorian-inc/tabularium/pkg/registry"
 )
 
@@ -22,6 +23,7 @@ var (
 
 type ADDomain struct {
 	BaseAsset
+	beta.Beta
 	Name string `neo4j:"name" json:"name" desc:"NetBIOS of the domain." example:"example.internal"`
 }
 


### PR DESCRIPTION
Adds the ability to tag types as "Beta", so Chariot can exclude them from certain API responses. 

Example usage:
```go
type ADDomain struct {
	BaseAsset
	beta.Beta
	Name string `neo4j:"name" json:"name" desc:"NetBIOS of the domain." example:"example.internal"`
}
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Introduced a beta marker that, when embedded in models, surfaces a beta flag in serialized outputs (JSON, map stores, DynamoDB) and is promoted to containing types when embedded (e.g., AD domain models).
  - Added support for the IS NULL operator in filters for null checks in queries.

- Tests
  - Added comprehensive tests validating beta flag serialization and unmarshaling standalone and when embedded, across JSON and DynamoDB formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->