### PR TITLE
Add AllowRepeat field to Job model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea/
+.claude-flow/
+.swarm/

--- a/pkg/model/model/job.go
+++ b/pkg/model/model/job.go
@@ -27,6 +27,7 @@ type Job struct {
 	Config                map[string]string `dynamodbav:"-" json:"config" desc:"Configuration parameters for the job capability." example:"{\"test\": \"cve-1111-2222\"}"`
 	LargeArtifactFileName string            `dynamodbav:"largeArtifactFileName" json:"largeArtifactFileName,omitempty" desc:"The name of the file that contains the large artifacts." example:"large_artifact.zip"`
 	S3DownloadURL         string            `dynamodbav:"s3DownloadURL" json:"s3DownloadURL,omitempty" desc:"The URL of the file that contains the large output." example:"https://s3.amazonaws.com/big_output.zip"`
+	AllowRepeat           bool              `dynamodbav:"allowRepeat" json:"allowRepeat" desc:"Indicates if repeating this job should be allowed. Used for manual jobs, or rescan jobs, that should not block other job executions." example:"false"`
 	Full                  bool              `dynamodbav:"-" json:"full,omitempty" desc:"Indicates if this is a full scan job." example:"false"`
 	Capabilities          []string          `dynamodbav:"-" json:"capabilities,omitempty" desc:"List of specific capabilities to run for this job." example:"[\"portscan\", \"nuclei\"]"`
 	Queue                 string            `dynamodbav:"-" desc:"Target queue for the job." example:"standard"`


### PR DESCRIPTION
## Summary
Added `AllowRepeat` boolean field to the Job model to support rescan functionality in the Chariot platform.

## Changes Made
- Added `AllowRepeat` field to Job struct with DynamoDB and JSON tags
- Field indicates when jobs should be allowed to repeat, bypassing duplicate job prevention
- Used for manual jobs and risk rescans that need to run even if previous jobs exist

## Technical Details
- Field type: `bool` 
- DynamoDB attribute: `allowRepeat`
- JSON field: `allowRepeat`
- Description: "Indicates if repeating this job should be allowed. Used for manual jobs, or rescan jobs, that should not block other job executions."
- Default value: `false`

This change supports the job rescan functionality being implemented in the Chariot backend.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Jobs now include an allowRepeat setting in API payloads, indicating whether a job can be repeated without blocking other executions. Defaults to false for existing data; no behavioral changes otherwise.

* Chores
  * Expanded Git ignore rules to exclude additional local development directories, reducing accidental commits of environment-specific files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->