### PR TITLE
Add EnableCallbacks data model for job Neo4j web service

### DIFF
--- a/pkg/model/model/capability.go
+++ b/pkg/model/model/capability.go
@@ -43,6 +43,8 @@ type Capability interface {
 	CheckAffiliation(Asset) (bool, error)
 	// Integration returns whether this capability is an integration
 	Integration() bool
+	// EnableCallbacks returns whether this capability requires web service callbacks for neo4j access
+	EnableCallbacks() bool
 	Lifecycle
 }
 

--- a/pkg/model/model/job.go
+++ b/pkg/model/model/job.go
@@ -29,6 +29,7 @@ type Job struct {
 	S3DownloadURL         string            `dynamodbav:"s3DownloadURL" json:"s3DownloadURL,omitempty" desc:"The URL of the file that contains the large output." example:"https://s3.amazonaws.com/big_output.zip"`
 	AllowRepeat           bool              `dynamodbav:"allowRepeat" json:"allowRepeat" desc:"Indicates if repeating this job should be allowed. Used for manual jobs, or rescan jobs, that should not block other job executions." example:"false"`
 	Full                  bool              `dynamodbav:"-" json:"full,omitempty" desc:"Indicates if this is a full scan job." example:"false"`
+	EnableCallbacks       bool              `dynamodbav:"enableCallbacks" json:"enableCallbacks" desc:"Indicates if the job should expose web service callbacks for neo4j access." example:"false"`
 	Capabilities          []string          `dynamodbav:"-" json:"capabilities,omitempty" desc:"List of specific capabilities to run for this job." example:"[\"portscan\", \"nuclei\"]"`
 	Queue                 string            `dynamodbav:"-" desc:"Target queue for the job." example:"standard"`
 	Target                TargetWrapper     `dynamodbav:"target" json:"target" desc:"The primary target of the job."`


### PR DESCRIPTION
## Summary
- Add `EnableCallbacks` boolean flag to Job model
- Add `EnableCallbacks()` method to Capability interface
- Support for conditional Neo4j web service exposure during job execution

## Data Model Changes

### Job Model (`pkg/model/model/job.go`)
```go
EnableCallbacks bool `dynamodbav:"enableCallbacks" json:"enableCallbacks"`
```
- Controls whether job should expose localhost web service
- Stored in DynamoDB with proper tags
- Defaults to false for backward compatibility

### Capability Interface (`pkg/model/model/capability.go`)
```go
// EnableCallbacks returns whether this capability requires web service callbacks for neo4j access
EnableCallbacks() bool
```
- Capabilities can declare if they need web service access
- Interface extension maintains backward compatibility

## Integration with Chariot
This data model supports the chariot implementation:
- **Conditional Activation**: Both `job.EnableCallbacks` AND `capability.EnableCallbacks()` must be true
- **Pre-Authentication**: Job username context automatically applied to all requests
- **Database Access**: Full user-scoped Neo4j operations via HTTP API

## API Usage (from chariot)
When enabled, spawned processes get access to:
- `POST localhost:8080/send` - Ingest data to Neo4j
- `GET|POST localhost:8080/my` - Query Neo4j data

## Backward Compatibility
- All existing jobs continue to work unchanged
- Default behavior is disabled (EnableCallbacks = false)
- Capabilities must explicitly opt-in to web service

🤖 Generated with [Claude Code](https://claude.ai/code)