### PR TITLE
Improve WebDiscovery

### DIFF
--- a/pkg/lib/normalize/normalize.go
+++ b/pkg/lib/normalize/normalize.go
@@ -32,12 +32,9 @@ func Normalize(rawURL string) (string, error) {
 }
 
 func RemoveDefaultPorts(u url.URL) url.URL {
-	h := u.Hostname()
 	p := u.Port()
-	if u.Scheme == "http" && p == "80" {
-		u.Host = h
-	} else if u.Scheme == "https" && p == "443" {
-		u.Host = h
+	if p == "80" || p == "443" {
+		u.Host = u.Hostname()
 	}
 	return u
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Default ports 80 and 443 are now stripped during URL normalization, ensuring cleaner, more consistent URLs.
  * Reduces duplicate entries where only a default port was present, improving comparisons and deduplication.
  * Harmonizes URL display across inputs that previously differed only by default port inclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->